### PR TITLE
build: bump textual to v0.48.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,12 +11,12 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 package_dir =
     = src
 packages = find:
 install_requires =
-    textual >= 0.39.0
+    textual >= 0.48.1
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Textual introduced many breaking changes to the TextArea in v0.48.1.

This breaks some functionality but the API is improved for extending the TextArea so just need to find the time to read through the docs/code!